### PR TITLE
Load_MAC option

### DIFF
--- a/hlagenie/__init__.py
+++ b/hlagenie/__init__.py
@@ -7,6 +7,7 @@ __version__ = "0.4.5"
 def init(
     imgt_version: str = "Latest",
     data_dir: str = None,
+    load_mac: bool = True,
     cache_size: int = config["DEFAULT_CACHE_SIZE"],
     ungap: bool = True,
     imputed: bool = False,
@@ -17,6 +18,7 @@ def init(
     genie = GENIE(
         imgt_version=imgt_version,
         data_dir=data_dir,
+        load_mac=load_mac,
         cache_size=cache_size,
         ungap=ungap,
         imputed=imputed,

--- a/hlagenie/data_repository.py
+++ b/hlagenie/data_repository.py
@@ -14,7 +14,7 @@ import pyard  # for HLA nomenclature
 
 
 def generate_gapped_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac: bool = True
 ):
     """
     Create tables with gapped sequences for every allele in the IMGT/HLA database for each locus
@@ -28,7 +28,7 @@ def generate_gapped_tables(
         return db.load_gapped_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version, load_mac)
+    ard = pyard.init(imgt_version, load_mac=load_mac)
 
     # initialize the dictionary to store all sequences
     gapped_seqs = {}
@@ -117,7 +117,7 @@ def generate_gapped_mature_tables(db_conn: sqlite3.Connection):
 
 # TODO - consider if this should leave positions which are simply unknown (current) or also remove these
 def generate_ungapped_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac: bool = True
 ):
     """
     Create tables with ungapped sequences for every allele in the IMGT/HLA database for each locus
@@ -131,7 +131,7 @@ def generate_ungapped_tables(
         return db.load_ungapped_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version, load_mac)
+    ard = pyard.init(imgt_version, load_mac=load_mac)
 
     # initialize the dictionary to store all sequences
     ungapped_seqs = {}
@@ -568,7 +568,7 @@ def generate_ungapped_xrd_table(db_conn: sqlite3.Connection, seqs: dict):
 
 
 def generate_ungapped_nuc_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
 ):
     """Generate a table with ungapped nucleotide sequences for every locus
 
@@ -580,8 +580,6 @@ def generate_ungapped_nuc_tables(
     if db.tables_exist(db_conn, config["ungapped_nuc_tables"]):
         return db.load_ungapped_nuc_tables(db_conn)
 
-    # initialize pyard object
-    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     ungapped_seqs = {}
@@ -639,7 +637,7 @@ def generate_ungapped_nuc_tables(
 
 
 def generate_gapped_nuc_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
 ):
     """
     Create tables with gapped nucleotide sequences for every allele in the IMGT/HLA database for each locus
@@ -651,9 +649,6 @@ def generate_gapped_nuc_tables(
     # check if the tables exist so as to not rebuild if unnecessary
     if db.tables_exist(db_conn, config["gapped_nuc_tables"]):
         return db.load_gapped_nuc_tables(db_conn)
-
-    # initialize pyard object
-    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     gapped_seqs = {}

--- a/hlagenie/data_repository.py
+++ b/hlagenie/data_repository.py
@@ -14,7 +14,7 @@ import pyard  # for HLA nomenclature
 
 
 def generate_gapped_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
 ):
     """
     Create tables with gapped sequences for every allele in the IMGT/HLA database for each locus
@@ -28,7 +28,7 @@ def generate_gapped_tables(
         return db.load_gapped_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version)
+    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     gapped_seqs = {}
@@ -117,7 +117,7 @@ def generate_gapped_mature_tables(db_conn: sqlite3.Connection):
 
 # TODO - consider if this should leave positions which are simply unknown (current) or also remove these
 def generate_ungapped_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
 ):
     """
     Create tables with ungapped sequences for every allele in the IMGT/HLA database for each locus
@@ -131,7 +131,7 @@ def generate_ungapped_tables(
         return db.load_ungapped_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version)
+    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     ungapped_seqs = {}
@@ -568,7 +568,7 @@ def generate_ungapped_xrd_table(db_conn: sqlite3.Connection, seqs: dict):
 
 
 def generate_ungapped_nuc_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
 ):
     """Generate a table with ungapped nucleotide sequences for every locus
 
@@ -581,7 +581,7 @@ def generate_ungapped_nuc_tables(
         return db.load_ungapped_nuc_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version)
+    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     ungapped_seqs = {}
@@ -639,7 +639,7 @@ def generate_ungapped_nuc_tables(
 
 
 def generate_gapped_nuc_tables(
-    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method
+    db_conn: sqlite3.Connection, imgt_version, imputed, imputation_method, load_mac
 ):
     """
     Create tables with gapped nucleotide sequences for every allele in the IMGT/HLA database for each locus
@@ -653,7 +653,7 @@ def generate_gapped_nuc_tables(
         return db.load_gapped_nuc_tables(db_conn)
 
     # initialize pyard object
-    ard = pyard.init(imgt_version)
+    ard = pyard.init(imgt_version, load_mac)
 
     # initialize the dictionary to store all sequences
     gapped_seqs = {}

--- a/hlagenie/genie.py
+++ b/hlagenie/genie.py
@@ -55,7 +55,7 @@ class GENIE:
         # load sequence data from database
         if self.ungap:
             self.full_seqs = dr.generate_ungapped_tables(
-                self.db_connection, imgt_version, imputed, imputation_method
+                self.db_connection, imgt_version, imputed, imputation_method, self.load_mac
             )
             self.nuc_seqs = dr.generate_ungapped_nuc_tables(
                 self.db_connection, imgt_version, imputed, imputation_method
@@ -65,7 +65,7 @@ class GENIE:
             self.xrds = dr.generate_ungapped_xrd_table(self.db_connection, self.seqs)
         else:
             self.full_seqs = dr.generate_gapped_tables(
-                self.db_connection, imgt_version, imputed, imputation_method
+                self.db_connection, imgt_version, imputed, imputation_method, self.load_mac
             )
             self.nuc_seqs = dr.generate_gapped_nuc_tables(
                 self.db_connection, imgt_version, imputed, imputation_method
@@ -96,7 +96,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the amino acid at the specified position
@@ -117,7 +117,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the nucleotide at the specified position
@@ -138,7 +138,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the amino acid substring
@@ -158,7 +158,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the epitope string
@@ -181,14 +181,14 @@ class GENIE:
                 allele1 = self.ard.redux(allele1, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele1 = self.ard.redux(allele1, "U2")
         if allele2.count(":") > 1:
             try:
                 allele2 = self.ard.redux(allele2, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele2 = self.ard.redux(allele2, "U2")
 
         # get the amino acid at the specified position for each allele
@@ -221,28 +221,28 @@ class GENIE:
                 allele1donor = self.ard.redux(allele1donor, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele1donor = self.ard.redux(allele1donor, "U2")
         if allele2donor.count(":") > 1:
             try:
                 allele2donor = self.ard.redux(allele2donor, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele2donor = self.ard.redux(allele2donor, "U2")
         if allele1recip.count(":") > 1:
             try:
                 allele1recip = self.ard.redux(allele1recip, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele1recip = self.ard.redux(allele1recip, "U2")
         if allele2recip.count(":") > 1:
             try:
                 allele2recip = self.ard.redux(allele2recip, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele2recip = self.ard.redux(allele2recip, "U2")
 
         # check if donor is homozygous
@@ -301,7 +301,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get locus
@@ -324,7 +324,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version, self.load_mac)
+                self.ard = pyard.init(self.imgt_version, load_mac=self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get locus

--- a/hlagenie/genie.py
+++ b/hlagenie/genie.py
@@ -21,6 +21,7 @@ class GENIE:
         self,
         imgt_version: str = "Latest",
         data_dir: str = None,
+        load_mac: bool = True,
         cache_size: int = config["DEFAULT_CACHE_SIZE"],
         ungap: bool = True,
         imputed: bool = False,
@@ -29,6 +30,7 @@ class GENIE:
         # set values for needed variables
         self._data_dir = data_dir
         self.ungap = ungap
+        self.load_mac = load_mac
 
         # if database version is "Latest", get the latest version
         if imgt_version == "Latest":
@@ -94,7 +96,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the amino acid at the specified position
@@ -115,7 +117,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the nucleotide at the specified position
@@ -136,7 +138,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the amino acid substring
@@ -156,7 +158,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get the epitope string
@@ -179,14 +181,14 @@ class GENIE:
                 allele1 = self.ard.redux(allele1, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele1 = self.ard.redux(allele1, "U2")
         if allele2.count(":") > 1:
             try:
                 allele2 = self.ard.redux(allele2, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele2 = self.ard.redux(allele2, "U2")
 
         # get the amino acid at the specified position for each allele
@@ -219,28 +221,28 @@ class GENIE:
                 allele1donor = self.ard.redux(allele1donor, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele1donor = self.ard.redux(allele1donor, "U2")
         if allele2donor.count(":") > 1:
             try:
                 allele2donor = self.ard.redux(allele2donor, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele2donor = self.ard.redux(allele2donor, "U2")
         if allele1recip.count(":") > 1:
             try:
                 allele1recip = self.ard.redux(allele1recip, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele1recip = self.ard.redux(allele1recip, "U2")
         if allele2recip.count(":") > 1:
             try:
                 allele2recip = self.ard.redux(allele2recip, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele2recip = self.ard.redux(allele2recip, "U2")
 
         # check if donor is homozygous
@@ -299,7 +301,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get locus
@@ -322,7 +324,7 @@ class GENIE:
                 allele = self.ard.redux(allele, "U2")
             except AttributeError:
                 # add an ard object
-                self.ard = pyard.init(self.imgt_version)
+                self.ard = pyard.init(self.imgt_version, self.load_mac)
                 allele = self.ard.redux(allele, "U2")
 
         # get locus


### PR DESCRIPTION
In py-ard, you have the option to not load in the MAC mapping when you initialize the module. In this edit, anytime py-ard was initialized in HLAGenie, it can be customized so as not to load the MAC mapping. 

Now when initializing HLAGenie you can write
```
import hlagenie

genie = hlagenie(load_mac=False)
```
The default is True, as when you first initialize py-ard or HLAGenie, you have to load in the MAC mapping, I believe, but anytime after that, you can skip that loading process, which will make HLAGenie run faster.